### PR TITLE
Port of twitch_auth.rs file to separate lib.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "twitch_oauth2_auth_flow"
+version = "0.0.1-alpha"
+authors = ["stuckoverflow2021"]
+edition = "2018"
+
+[dependencies]
+futures = "0.3"
+log = "0.4"
+oauth2 = "4.0.0-alpha"
+tiny_http = "0.6"
+# Until https://github.com/Emilgardis/twitch_api2/issues/62 is resolved, this
+# crate will only compile when it can locate a local version of twitch_api2
+# under `../twitch_api2`. This is in order to make it compatible with the other
+# repos who are currently importing twitch_api2 as git submodule since  they are
+# using unreleased code.
+twitch_oauth2 = { version = "0.5.0-alpha", features = ["surf_client"], path = "../twitch_api2/twitch_oauth2/" }
+url = "2.2"
+
+[dev-dependencies]
+surf = "2.2"
+tokio = { version = "1", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,141 @@
+use futures::executor::block_on;
+use log::{debug, error};
+use tiny_http::{Response, Server, StatusCode};
+use twitch_oauth2::{tokens::UserTokenBuilder, ClientId, ClientSecret, Scope, UserToken};
+use url::Url;
+
+/// Twitch authentication flow.
+pub fn auth_flow(client_id: &str, client_secret: &str, scopes: Option<Vec<Scope>>) -> UserToken {
+    let mut hook = TwitchAuthHook::new(String::from(client_id), String::from(client_secret), scopes, 10666);
+    let (url, csrf) = hook.builder.generate_url();
+    println!(
+        "To obtain an authentication token, please visit\n{}",
+        url.as_str().to_owned()
+    );
+    let code = hook.receive_auth_token().unwrap();
+    let user_token = block_on(async {
+        hook.builder
+            .get_user_token(
+                twitch_oauth2::client::surf_http_client,
+                csrf.secret(),
+                &code,
+            )
+            .await
+    });
+    user_token.unwrap()
+}
+
+// Internal implementation.
+struct TwitchAuthHook {
+    http_server: Server,
+    builder: UserTokenBuilder,
+}
+
+impl TwitchAuthHook {
+    fn new(client_id: String, client_secret: String, scopes: Option<Vec<Scope>>, port: i32) -> TwitchAuthHook {
+        let http_server = Server::http(format!("0.0.0.0:{}", port)).unwrap();
+        let redirect_url = oauth2::RedirectUrl::new(format!(
+            "http://localhost:{}",
+            http_server.server_addr().port()
+        ))
+        .unwrap();
+        let mut builder = UserToken::builder(
+            ClientId::new(client_id),
+            ClientSecret::new(client_secret),
+            redirect_url,
+        )
+        .unwrap()
+        .force_verify(true);
+        if let Some(scopes) = scopes {
+            builder = builder.set_scopes(scopes);
+        }
+        TwitchAuthHook {
+            http_server,
+            builder,
+        }
+    }
+
+    fn receive_auth_token(&self) -> Result<String, ()> {
+        let mut code: Option<String> = None;
+        loop {
+            match self.http_server.recv() {
+                Ok(rq) => {
+                    debug!("request: {:?}", rq);
+                    let url = format!(
+                        "http://localhost:{}{}",
+                        self.http_server.server_addr().port(),
+                        rq.url()
+                    );
+                    let url = Url::parse(&url).unwrap();
+                    if url.path() != "/" {
+                        rq.respond(Response::from_string("KO").with_status_code(StatusCode(500)))
+                            .unwrap();
+                        continue;
+                    }
+
+                    for (key, value) in url.query_pairs() {
+                        match &*key {
+                            "code" => code = Some(value.into_owned()),
+                            _ => continue,
+                        }
+                    }
+                    if code != None {
+                        rq.respond(Response::from_string("OK")).unwrap();
+                        break;
+                    } else {
+                        rq.respond(Response::from_string("KO").with_status_code(StatusCode(500)))
+                            .unwrap();
+                        continue;
+                    }
+                }
+                Err(e) => {
+                    error!("error: {}", e)
+                }
+            };
+        }
+
+        match code {
+            Some(c) => Ok(c),
+            None => Err(()),
+        }
+    }
+}
+
+// Tests.
+#[cfg(test)]
+mod tests {
+    use surf::StatusCode;
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn receive_auth_token_redirect() {
+        let client_id = "xxxxxx".to_owned();
+        let client_secret = "".to_owned();
+        let hook = TwitchAuthHook::new(client_id.clone(), client_secret.clone(), 0);
+        let server_port = hook.http_server.server_addr().port();
+        let received_auth_code = tokio::spawn(async move { hook.receive_auth_token() });
+
+        let expected_auth_code = "XXXXXXXX";
+        let expected_auth_code_clone = expected_auth_code.clone();
+        let testing_driver = tokio::spawn(async move {
+            let http_address = format!("http://localhost:{}", server_port);
+            // make a bogus requests to ensure the server doesn't quit.
+            surf::get(&format!("{}/favicon.ico", http_address))
+                .await
+                .unwrap();
+            // now the real request.
+            surf::get(&format!(
+                "{}/?code={}&scope=chat%3Aread+chat%3Aedit",
+                http_address, expected_auth_code_clone
+            ))
+            .await
+            .unwrap()
+        });
+
+        let response = testing_driver.await.unwrap();
+        assert_eq!(response.status(), StatusCode::Ok);
+        let received_auth_code = received_auth_code.await.unwrap();
+        assert_eq!(received_auth_code, Ok(expected_auth_code.to_owned()));
+    }
+}


### PR DESCRIPTION
The `src/lib.rs` file is a direct port of
[`twitch_auth.rs`](https://github.com/stuck-overflow/ferris-bot/blob/fcd3d380cf3adccaed486c97a0a4ca0268884bb1/src/twitch_auth.rs)

This library temporarily requires the twitch_api2 library to be
available as a "sister" directory (i.e. in `../twitch_api2`). This is
needed since our other projects are using unreleased features of
twitch_api2 and we need to build against the same codebase.

Part of https://github.com/stuck-overflow/ferris-bot/issues/50