### PR TITLE
some changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+**/.env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,13 @@ edition = "2018"
 [dependencies]
 futures = "0.3"
 log = "0.4"
-oauth2 = "4.0.0-alpha"
 tiny_http = "0.6"
-twitch_api2 = { features = ["client", "helix", "surf_client", "twitch_oauth2"], git = "https://github.com/Emilgardis/twitch_api2/", branch = "master"  }
-twitch_oauth2 = { features = ["surf_client"], git = "https://github.com/Emilgardis/twitch_oauth2/", branch = "master"  }
+twitch_oauth2 = { features = ["surf_client"], version = "0.5.0-beta.1"  }
+surf = "2.2.0"
 url = "2.2"
+thiserror = "1"
 
 [dev-dependencies]
 surf = "2.2"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
+dotenv = "0.15.0"

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,0 +1,25 @@
+//! Example of auth flow.
+//!
+//! To use this, set the environment variables `CLIENT_ID` and `CLIENT_SECRET` to their respective values.
+//! See <https://dev.twitch.tv/docs/authentication#registration> for more information
+//!
+//! You'll need to add `http://localhost:10666/twitch/token` to your redirect URIs. (You can also override the url with the first argument passed to the executable)
+use std::env;
+use twitch_oauth2_auth_flow::auth_flow;
+
+#[tokio::main]
+async fn main() {
+    let _ = dotenv::dotenv();
+    let client_id = get_var("CLIENT_ID");
+    let client_secret = get_var("CLIENT_SECRET");
+    let redirect_url = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "http://localhost:10666/twitch/token".to_string());
+    let scopes = None;
+    let res = auth_flow(&client_id, &client_secret, scopes, &redirect_url);
+    println!("got result: {:?}", res);
+}
+
+fn get_var(var: &'static str) -> String {
+    env::var(var).unwrap_or_else(|e| panic!("Could not get env {} - {}", var, e))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,153 +1,191 @@
 use futures::executor::block_on;
 use log::{debug, error};
 use tiny_http::{Response, Server, StatusCode};
-use twitch_api2::twitch_oauth2::{
-    tokens::UserTokenBuilder, ClientId, ClientSecret, Scope, UserToken,
+use twitch_oauth2::{
+    client::SurfError,
+    tokens::{errors::UserTokenExchangeError, UserTokenBuilder},
+    ClientId, ClientSecret, CsrfToken, Scope, UserToken,
 };
 use url::Url;
 
+/// Errors for [`auth_flow`]
+#[derive(Debug, thiserror::Error)]
+pub enum AuthFlowError {
+    #[error(transparent)]
+    HookError(#[from] HookError),
+    #[error("could not parse url")]
+    UrlParseError(#[from] url::ParseError),
+}
+
+/// Hook errors for [`TwitchAuthHook`]
+#[derive(Debug, thiserror::Error)]
+pub enum HookError {
+    #[error("when constructing http server")]
+    TinyHttpError(#[source] Box<(dyn std::error::Error + Sync + Send + 'static)>),
+    #[error("could not parse url")]
+    UrlParseError(#[from] url::ParseError),
+    #[error("failed to do IO operation")]
+    IoError(#[from] std::io::Error),
+    #[error("talking with twitch authentication failed")]
+    ExchangeError(#[from] UserTokenExchangeError<SurfError>),
+}
+
 /// Twitch authentication flow.
-pub fn auth_flow(client_id: &str, client_secret: &str, scopes: Option<Vec<Scope>>) -> UserToken {
+///
+/// This token will only be valid for around 4 hours, but you can refresh the token with [`UserToken::refresh_token`](twitch_oauth2::TwitchToken::refresh_token)
+pub fn auth_flow(
+    client_id: &str,
+    client_secret: &str,
+    scopes: Option<Vec<Scope>>,
+    redirect_url: &str,
+) -> Result<UserToken, AuthFlowError> {
+    let redirect_url = Url::parse(&redirect_url)?;
     let mut hook = TwitchAuthHook::new(
         String::from(client_id),
         String::from(client_secret),
         scopes,
-        10666,
-    );
-    let (url, csrf) = hook.builder.generate_url();
+        redirect_url,
+    )?;
+    let (url, _) = hook.generate_url();
     println!(
         "To obtain an authentication token, please visit\n{}",
         url.as_str().to_owned()
     );
-    let code = hook.receive_auth_token().unwrap();
-    let user_token = block_on(async {
-        hook.builder
-            .get_user_token(
-                twitch_oauth2::client::surf_http_client,
-                csrf.secret(),
-                &code,
-            )
-            .await
-    });
-    user_token.unwrap()
+    block_on(async { hook.receive_auth_token().await }).map_err(Into::into)
 }
 
-// Internal implementation.
-struct TwitchAuthHook {
-    http_server: Server,
+/// Token generator using [OAuth authorization code flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#oauth-authorization-code-flow)
+///
+/// Spins up a small webserver that listens for a response from the user after they are redirected to the redirect URL by twitch.
+///
+/// See [`auth_flow`] for a more integrated way of using this.
+///
+/// Make a new [`TwitchAuthHook`] and call [`generate_url()`](TwitchAuthHook::generate_url) and make the user navigate to the url.
+/// Retrieve the token with [`receive_auth_token`](TwitchAuthHook::receive_auth_token).
+///
+/// # Example
+///
+/// ```rust, no_run
+/// use twitch_oauth2_auth_flow::TwitchAuthHook;
+/// use twitch_oauth2::{TwitchToken, UserToken, Scope};
+/// use url::Url;
+///
+/// let mut hook = TwitchAuthHook::new(
+///     "my_client_id".to_string(),
+///     "my_client_secret".to_string(),
+///     vec![Scope::ChatRead, Scope::ChatEdit, Scope::ChannelModerate, Scope::ModerationRead]
+///     Url::parse("http://localhost:8081/twitch/token")?,
+/// )?;
+///
+/// let (url, _) = hook.generate_url();
+/// give_url_to_user(url);
+/// let token = hook.receive_auth_token()?;
+/// # fn give_url_to_user(_: impl std::any::Any ) {}
+/// # Ok::<(), Box<std::error::Error + 'static>>(())
+/// ```
+pub struct TwitchAuthHook {
     builder: UserTokenBuilder,
+    redirect_url: Url,
+    port: u16,
 }
 
 impl TwitchAuthHook {
-    fn new(
+    /// Construct a new [`TwitchAuthHook`]
+    pub fn new(
         client_id: String,
         client_secret: String,
-        scopes: Option<Vec<Scope>>,
-        port: i32,
-    ) -> TwitchAuthHook {
-        let http_server = Server::http(format!("0.0.0.0:{}", port)).unwrap();
-        let redirect_url = oauth2::RedirectUrl::new(format!(
-            "http://localhost:{}",
-            http_server.server_addr().port()
-        ))
-        .unwrap();
+        scopes: impl Into<Option<Vec<Scope>>>,
+        redirect_url: Url,
+    ) -> Result<TwitchAuthHook, HookError> {
+        let redirect = twitch_oauth2::RedirectUrl::from_url(redirect_url.clone());
+        let port = redirect.url().port_or_known_default().unwrap_or(80);
         let mut builder = UserToken::builder(
             ClientId::new(client_id),
             ClientSecret::new(client_secret),
-            redirect_url,
+            redirect,
         )
-        .unwrap()
+        .expect("unexpected failure to construct urls to twitch")
         .force_verify(true);
-        if let Some(scopes) = scopes {
+        if let Some(scopes) = scopes.into() {
             builder = builder.set_scopes(scopes);
         }
-        TwitchAuthHook {
-            http_server,
+        Ok(TwitchAuthHook {
             builder,
-        }
+            redirect_url,
+            port,
+        })
     }
 
-    fn receive_auth_token(&self) -> Result<String, ()> {
-        let mut code: Option<String> = None;
-        loop {
-            match self.http_server.recv() {
+    /// Generate the url and csrf token associated with this [`TwitchAuthHook`]
+    pub fn generate_url(&mut self) -> (Url, CsrfToken) {
+        self.builder.generate_url()
+    }
+
+    /// Override the implicit port for the server as given by the redirect url.
+    ///
+    /// Useful if the application is behind a reverse-proxy
+    pub fn set_port(&mut self, port: u16) {
+        self.port = port;
+    }
+
+    /// Spin up a server to retrieve the token from the user.
+    ///
+    /// This token will only be valid for around 4 hours, but you can refresh the token with [`UserToken::refresh_token`](twitch_oauth2::TwitchToken::refresh_token)
+    pub async fn receive_auth_token(self) -> Result<UserToken, HookError> {
+        let http_server =
+            Server::http(format!("0.0.0.0:{}", self.port)).map_err(HookError::TinyHttpError)?;
+        let (code, state) = loop {
+            match http_server.recv() {
                 Ok(rq) => {
                     debug!("request: {:?}", rq);
                     let url = format!(
                         "http://localhost:{}{}",
-                        self.http_server.server_addr().port(),
+                        http_server.server_addr().port(),
                         rq.url()
                     );
-                    let url = Url::parse(&url).unwrap();
-                    if url.path() != "/" {
-                        rq.respond(Response::from_string("KO").with_status_code(StatusCode(500)))
-                            .unwrap();
+                    let url = Url::parse(&url)?;
+                    // Check if the path the user navigated to matches the redirect url.
+                    if url.path() != self.redirect_url.path() {
+                        rq.respond(Response::from_string("KO").with_status_code(StatusCode(500)))?;
                         continue;
                     }
 
-                    for (key, value) in url.query_pairs() {
-                        match &*key {
-                            "code" => code = Some(value.into_owned()),
-                            _ => continue,
+                    let query: std::collections::HashMap<_, _> = url.query_pairs().collect();
+
+                    match (query.get("code"), query.get("state")) {
+                        (Some(code), Some(state)) => {
+                            rq.respond(Response::from_string("OK"))?;
+                            break (code.to_string(), state.to_string());
                         }
-                    }
-                    if code != None {
-                        rq.respond(Response::from_string("OK")).unwrap();
-                        break;
-                    } else {
-                        rq.respond(Response::from_string("KO").with_status_code(StatusCode(500)))
-                            .unwrap();
-                        continue;
+                        _ => match (query.get("error"), query.get("error_description")) {
+                            (None, None) => {
+                                rq.respond(
+                                    Response::from_string("KO").with_status_code(StatusCode(500)),
+                                )?;
+                                continue;
+                            }
+                            (e, d) => {
+                                rq.respond(
+                                    Response::from_string(&format!(
+                                        "Error: {} - {}",
+                                        e.map(|e| e.as_ref()).unwrap_or(""),
+                                        d.map(|e| e.as_ref()).unwrap_or("")
+                                    ))
+                                    .with_status_code(400),
+                                )?;
+                                continue;
+                            }
+                        },
                     }
                 }
                 Err(e) => {
                     error!("error: {}", e)
                 }
-            };
-        }
-
-        match code {
-            Some(c) => Ok(c),
-            None => Err(()),
-        }
-    }
-}
-
-// Tests.
-#[cfg(test)]
-mod tests {
-    use surf::StatusCode;
-
-    use super::*;
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn receive_auth_token_redirect() {
-        let client_id = "xxxxxx".to_owned();
-        let client_secret = "".to_owned();
-        let hook = TwitchAuthHook::new(client_id.clone(), client_secret.clone(), 0);
-        let server_port = hook.http_server.server_addr().port();
-        let received_auth_code = tokio::spawn(async move { hook.receive_auth_token() });
-
-        let expected_auth_code = "XXXXXXXX";
-        let expected_auth_code_clone = expected_auth_code.clone();
-        let testing_driver = tokio::spawn(async move {
-            let http_address = format!("http://localhost:{}", server_port);
-            // make a bogus requests to ensure the server doesn't quit.
-            surf::get(&format!("{}/favicon.ico", http_address))
-                .await
-                .unwrap();
-            // now the real request.
-            surf::get(&format!(
-                "{}/?code={}&scope=chat%3Aread+chat%3Aedit",
-                http_address, expected_auth_code_clone
-            ))
+            }
+        };
+        self.builder
+            .get_user_token(twitch_oauth2::client::surf_http_client, &state, &code)
             .await
-            .unwrap()
-        });
-
-        let response = testing_driver.await.unwrap();
-        assert_eq!(response.status(), StatusCode::Ok);
-        let received_auth_code = received_auth_code.await.unwrap();
-        assert_eq!(received_auth_code, Ok(expected_auth_code.to_owned()));
+            .map_err(Into::into)
     }
 }


### PR DESCRIPTION
- update twitch_oauth2
- remove unnecessary stuff
- fix csrf validation
- add proper errors
- make it possible to override what path the server "listens" on
- make `TwitchAuthHook::receive_auth_token` async

also adds an example instead of a test.